### PR TITLE
Miniaudio-related structs/classes.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,3 +2,4 @@ BasedOnStyle: LLVM
 IndentWidth: 4
 DerivePointerAlignment: false
 PointerAlignment: Right
+ColumnLimit: 100

--- a/include/maudio.hpp
+++ b/include/maudio.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <atomic>
+
+#include "miniaudio.h"
+
+namespace trm {
+
+struct MaDeviceSpecifiers {
+    static constexpr ma_format format{ma_format_s16};
+    static constexpr ma_uint32 channels{2};
+    static constexpr ma_uint32 sampleRate{48000};
+    static constexpr ma_device_type deviceType{ma_device_type_playback};
+};
+
+struct MaDevice {
+    ma_device_config devConfig{};
+    ma_device dev{};
+    static void callback(ma_device* device, void* out, const void* in, unsigned int frames);
+};
+
+struct DeviceState {
+    std::atomic<bool> playback{};
+    std::atomic<bool> muted{};
+    std::atomic<float> volume{};
+};
+
+class AudioDevice {
+    MaDeviceSpecifiers devSpec{};
+    MaDevice device{};
+    DeviceState state{};
+
+  public:
+    AudioDevice();
+    ~AudioDevice();
+};
+
+} // namespace trm

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -1,6 +1,8 @@
 #pragma once
 #include <iostream>
+#include <stdexcept>
 
+#define ERR_LIST E(GENERIC_EXCEPTION, "A generic exception has been thrown.")
 namespace trm {
 
 inline void clearConsole() { std::cout << "\033[2J\033[H" << std::flush; }
@@ -9,6 +11,25 @@ inline void showError(const std::string &errMsg) {
     clearConsole();
     std::cout << "\e[0;31m" << "THROWN EXCEPTION:\n"
               << errMsg << "\e[0m" << std::endl;
+}
+
+enum class Error {
+    #define E(err, str) err,
+    ERR_LIST
+    #undef E
+    COUNT
+};
+
+constexpr const char* errMsg[static_cast<std::size_t>(Error::COUNT)] = {
+    #define E(err, str) str,
+    ERR_LIST
+    #undef E
+};
+
+inline void require(const bool cond, const Error err) {
+    if (!cond) {
+        throw std::runtime_error(errMsg[static_cast<std::size_t>(err)]);
+    }
 }
 
 } // namespace trm

--- a/src/maudio.cpp
+++ b/src/maudio.cpp
@@ -1,0 +1,23 @@
+#include "maudio.hpp"
+
+namespace trm {
+
+AudioDevice::AudioDevice() {
+    device.devConfig.playback.format = devSpec.format;
+    device.devConfig.playback.channels = devSpec.channels;
+    device.devConfig.sampleRate = devSpec.sampleRate;
+    device.devConfig.deviceType = devSpec.deviceType;
+    device.devConfig.dataCallback = device.callback;
+    device.devConfig.pUserData = static_cast<void*>(this);
+    ma_device_init(nullptr, &device.devConfig, &device.dev);
+}
+
+AudioDevice::~AudioDevice() {
+   ma_device_uninit(&device.dev);
+}
+
+void MaDevice::callback(ma_device *device, void *out, const void *in, unsigned int frames) {
+        
+}
+
+}


### PR DESCRIPTION
Added .clang-format file, class outline, constructor implementation for Miniaudio-related structs and classes.